### PR TITLE
Upgrade to .NET 9 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ShoesContainer
-.NET 5 microservice (Web Api + MVC for front-end)
+.NET 9 microservice (Web Api + MVC for front-end)
 
 
 To run the project on docker 

--- a/ShoeContainer/src/Services/ProductCatalogApi/Dockerfile
+++ b/ShoeContainer/src/Services/ProductCatalogApi/Dockerfile
@@ -1,7 +1,7 @@
 ﻿# run in terminal docker build -t shoes/catalog .
 
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0.404 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 
 
 WORKDIR /code
@@ -13,7 +13,7 @@ COPY . .
 RUN dotnet publish -c release -o /app 
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/aspnet:5.0.13
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
 
 WORKDIR /app
 COPY --from=build /app ./

--- a/ShoeContainer/src/Services/ProductCatalogApi/ProductCatalogApi.csproj
+++ b/ShoeContainer/src/Services/ProductCatalogApi/ProductCatalogApi.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <RootNamespace>ShoesOnContainers.Services.ProductCatalogApi</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.13" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.13" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.13">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ShoeContainer/src/Services/TokenServiceApi/Config.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Config.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
-using IdentityServer4;
-using IdentityServer4.Models;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Models;
 using Microsoft.Extensions.Configuration;
 
 namespace ShoesOnContainers.Services.TokenServiceApi
@@ -21,8 +21,23 @@ namespace ShoesOnContainers.Services.TokenServiceApi
         {
             return new List<ApiResource>
             {
-                 new ApiResource("basket", "Shopping Cart Api"),
-                 new ApiResource("orders", "Ordering Api"),
+                 new ApiResource("basket", "Shopping Cart Api")
+                 {
+                     Scopes = { "basket" }
+                 },
+                 new ApiResource("orders", "Ordering Api")
+                 {
+                     Scopes = { "orders" }
+                 },
+            };
+        }
+
+        public static IEnumerable<ApiScope> GetApiScopes()
+        {
+            return new List<ApiScope>
+            {
+                new ApiScope("basket", "Shopping Cart Api"),
+                new ApiScope("orders", "Ordering Api"),
             };
         }
 

--- a/ShoeContainer/src/Services/TokenServiceApi/Controllers/AccountController.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Controllers/AccountController.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using IdentityServer4.Quickstart.UI;
-using IdentityServer4.Services;
+using Duende.IdentityServer.Quickstart.UI;
+using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -33,6 +33,7 @@ namespace ShoesOnContainers.Services.TokenServiceApi.Controllers
             SignInManager<ApplicationUser> signInManager,
             IIdentityServerInteractionService interaction,
             IHttpContextAccessor httpContextAccessor,
+            IAuthenticationSchemeProvider schemeProvider,
             IEmailSender emailSender,
             ILogger<AccountController> logger)
         {
@@ -41,7 +42,7 @@ namespace ShoesOnContainers.Services.TokenServiceApi.Controllers
             _emailSender = emailSender;
             _logger = logger;
             _interaction = interaction;
-            _account = new AccountService(interaction, httpContextAccessor);
+            _account = new AccountService(interaction, httpContextAccessor, schemeProvider);
         }
 
         [TempData]

--- a/ShoeContainer/src/Services/TokenServiceApi/Controllers/HomeController.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Controllers/HomeController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 
-using IdentityServer4.Services;
+using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Mvc;
 using ShoesOnContainers.Services.TokenServiceApi.Models;
 using TokenServiceApi.Models;

--- a/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Account/AccountOptions.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Account/AccountOptions.cs
@@ -4,7 +4,7 @@
 
 using System;
 
-namespace IdentityServer4.Quickstart.UI
+namespace Duende.IdentityServer.Quickstart.UI
 {
     public class AccountOptions
     {

--- a/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Account/LoggedOutViewModel.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Account/LoggedOutViewModel.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-namespace IdentityServer4.Quickstart.UI
+namespace Duende.IdentityServer.Quickstart.UI
 {
     public class LoggedOutViewModel
     {

--- a/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Account/LogoutInputModel.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Account/LogoutInputModel.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-namespace IdentityServer4.Quickstart.UI
+namespace Duende.IdentityServer.Quickstart.UI
 {
     public class LogoutInputModel
     {

--- a/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Account/LogoutViewModel.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Account/LogoutViewModel.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-namespace IdentityServer4.Quickstart.UI
+namespace Duende.IdentityServer.Quickstart.UI
 {
     public class LogoutViewModel : LogoutInputModel
     {

--- a/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Consent/ConsentController.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Consent/ConsentController.cs
@@ -2,13 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4.Services;
-using IdentityServer4.Stores;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
-namespace IdentityServer4.Quickstart.UI
+namespace Duende.IdentityServer.Quickstart.UI
 {
     /// <summary>
     /// This controller processes the consent UI

--- a/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Consent/ConsentInputModel.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Consent/ConsentInputModel.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 
-namespace IdentityServer4.Quickstart.UI
+namespace Duende.IdentityServer.Quickstart.UI
 {
     public class ConsentInputModel
     {

--- a/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Consent/ConsentOptions.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Consent/ConsentOptions.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-namespace IdentityServer4.Quickstart.UI
+namespace Duende.IdentityServer.Quickstart.UI
 {
     public class ConsentOptions
     {

--- a/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Consent/ConsentViewModel.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Consent/ConsentViewModel.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 
-namespace IdentityServer4.Quickstart.UI
+namespace Duende.IdentityServer.Quickstart.UI
 {
     public class ConsentViewModel : ConsentInputModel
     {

--- a/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Consent/ProcessConsentResult.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Consent/ProcessConsentResult.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-namespace IdentityServer4.Quickstart.UI
+namespace Duende.IdentityServer.Quickstart.UI
 {
     public class ProcessConsentResult
     {

--- a/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Consent/ScopeViewModel.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Consent/ScopeViewModel.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-namespace IdentityServer4.Quickstart.UI
+namespace Duende.IdentityServer.Quickstart.UI
 {
     public class ScopeViewModel
     {

--- a/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Grants/GrantsController.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Grants/GrantsController.cs
@@ -2,21 +2,21 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4.Services;
-using IdentityServer4.Stores;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 
-namespace IdentityServer4.Quickstart.UI
+namespace Duende.IdentityServer.Quickstart.UI
 {
     /// <summary>
     /// This sample controller allows a user to revoke grants given to clients
     /// </summary>
     [SecurityHeaders]
-    [Authorize(AuthenticationSchemes = IdentityServer4.IdentityServerConstants.DefaultCookieAuthenticationScheme)]
+    [Authorize(AuthenticationSchemes = Duende.IdentityServer.IdentityServerConstants.DefaultCookieAuthenticationScheme)]
     public class GrantsController : Controller
     {
         private readonly IIdentityServerInteractionService _interaction;
@@ -54,7 +54,7 @@ namespace IdentityServer4.Quickstart.UI
 
         private async Task<GrantsViewModel> BuildViewModelAsync()
         {
-            var grants = await _interaction.GetAllUserConsentsAsync();
+            var grants = await _interaction.GetAllUserGrantsAsync();
 
             var list = new List<GrantViewModel>();
             foreach(var grant in grants)

--- a/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Grants/GrantsViewModel.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Grants/GrantsViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace IdentityServer4.Quickstart.UI
+namespace Duende.IdentityServer.Quickstart.UI
 {
     public class GrantsViewModel
     {

--- a/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Home/ErrorViewModel.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Quickstart/Home/ErrorViewModel.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityServer4.Models;
+using Duende.IdentityServer.Models;
 
-namespace IdentityServer4.Quickstart.UI
+namespace Duende.IdentityServer.Quickstart.UI
 {
     public class ErrorViewModel
     {

--- a/ShoeContainer/src/Services/TokenServiceApi/Quickstart/SecurityHeadersAttribute.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Quickstart/SecurityHeadersAttribute.cs
@@ -5,7 +5,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
-namespace IdentityServer4.Quickstart.UI
+namespace Duende.IdentityServer.Quickstart.UI
 {
     public class SecurityHeadersAttribute : ActionFilterAttribute
     {

--- a/ShoeContainer/src/Services/TokenServiceApi/Startup.cs
+++ b/ShoeContainer/src/Services/TokenServiceApi/Startup.cs
@@ -42,9 +42,8 @@ namespace ShoesOnContainers.Services.TokenServiceApi
             
             // configure identity server with in-memory stores, keys, clients and scopes
             services.AddIdentityServer()
-                .AddDeveloperSigningCredential()
-                .AddInMemoryPersistedGrants()
                 .AddInMemoryIdentityResources(Config.GetIdentityResources())
+                .AddInMemoryApiScopes(Config.GetApiScopes())
                 .AddInMemoryApiResources(Config.GetApiResources())
                 .AddInMemoryClients(Config.GetClients(Config.GetUrls(Configuration)))
                 .AddAspNetIdentity<ApplicationUser>();
@@ -68,7 +67,8 @@ namespace ShoesOnContainers.Services.TokenServiceApi
             app.UseStaticFiles();
 
             app.UseRouting();
-
+            
+            app.UseIdentityServer();
             app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>

--- a/ShoeContainer/src/Services/TokenServiceApi/TokenServiceApi.csproj
+++ b/ShoeContainer/src/Services/TokenServiceApi/TokenServiceApi.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <UserSecretsId>aspnet-TokenServiceApi-EFAFA511-7C6B-4F52-9A6F-4980AD4A8338</UserSecretsId>
     <RootNamespace>ShoesOnContainers.Services.TokenServiceApi</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityServer4" Version="2.0.1" />
-    <PackageReference Include="IdentityServer4.AspNetIdentity" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.13" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.13" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="5.0.13" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.13" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.13" />
+    <PackageReference Include="Duende.IdentityServer" Version="7.0.8" />
+    <PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ShoeContainer/src/Services/TokenServiceApi/Views/Account/Logout.cshtml
+++ b/ShoeContainer/src/Services/TokenServiceApi/Views/Account/Logout.cshtml
@@ -1,4 +1,4 @@
-﻿@model IdentityServer4.Quickstart.UI.LogoutViewModel
+﻿@model Duende.IdentityServer.Quickstart.UI.LogoutViewModel
 
 <div class="logout-page">
     <div class="page-header">

--- a/ShoeContainer/src/Services/TokenServiceApi/Views/Consent/_ScopeListItem.cshtml
+++ b/ShoeContainer/src/Services/TokenServiceApi/Views/Consent/_ScopeListItem.cshtml
@@ -1,4 +1,4 @@
-﻿@model IdentityServer4.Quickstart.UI.ScopeViewModel
+﻿@model Duende.IdentityServer.Quickstart.UI.ScopeViewModel
 
 <li class="list-group-item">
     <label>

--- a/ShoeContainer/src/Services/TokenServiceApi/Views/_ViewImports.cshtml
+++ b/ShoeContainer/src/Services/TokenServiceApi/Views/_ViewImports.cshtml
@@ -3,5 +3,5 @@
 @using ShoesOnContainers.Services.TokenServiceApi.Models
 @using ShoesOnContainers.Services.TokenServiceApi.Models.AccountViewModels
 @using ShoesOnContainers.Services.TokenServiceApi.Models.ManageViewModels
-@using IdentityServer4.Quickstart.UI
+@using Duende.IdentityServer.Quickstart.UI
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/ShoeContainer/src/Web/WebMvc/Dockerfile
+++ b/ShoeContainer/src/Web/WebMvc/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/sdk:5.0.404 AS build
+﻿FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /app
 
 # copy csproj and restore as distinct layers
@@ -11,7 +11,7 @@ COPY . ./
 RUN dotnet publish -c Release -o out
 
 # build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:5.0.13
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
 WORKDIR /app
 COPY --from=build /app/out .
 

--- a/ShoeContainer/src/Web/WebMvc/WebMvc.csproj
+++ b/ShoeContainer/src/Web/WebMvc/WebMvc.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>disable</Nullable>
         <RootNamespace>ShoesOnContainers.Web.WebMvc</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="2.0.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgrade to .NET 9 and migrate to Duende IdentityServer

Upgraded the project from .NET 5/7 to .NET 9 across all components, including updates to Docker images, project files, and dependencies. Replaced IdentityServer4 with Duende IdentityServer, updating all relevant namespaces, APIs, and configurations.

Refactored consent and grants handling to align with Duende's API, introduced `ApiScope` definitions, and updated Razor views for compatibility. Added `IAuthenticationSchemeProvider` for external provider sign-out. Updated the `Startup.cs` pipeline to use `app.UseIdentityServer()`.

Updated the README to reflect the .NET 9 upgrade and performed minor refactoring and cleanup for maintainability.